### PR TITLE
Enable using gene symbol as input and enable test on in-house lists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: allez
-Version: 2.0.3
-Date: 2015-05-26
+Version: 2.0.4
+Date: 2015-06-09
 Title: Random-set calibration of gene-set statistics
 Author: Michael Newton <newton@stat.wisc.edu>, Subhrangshu Nandi, and Aimee Teo Broman
 Maintainer: Aimee Teo Broman <abroman@biostat.wisc.edu>
@@ -10,4 +10,4 @@ Suggests: hgu133plus2.db, GO.db, KEGG.db, reactome.db
 LazyLoad: yes
 LazyData: yes
 License: GPL (>= 2)
-Packaged: 2015-05-26; abroman
+Packaged: 2015-06-09; ningleng

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: allez
 Version: 2.0.4
-Date: 2015-06-09
+Date: 2015-06-16
 Title: Random-set calibration of gene-set statistics
-Author: Michael Newton <newton@stat.wisc.edu>, Subhrangshu Nandi, and Aimee Teo Broman
+Author: Michael Newton <newton@stat.wisc.edu>, Subhrangshu Nandi, Ning Leng and Aimee Teo Broman
 Maintainer: Aimee Teo Broman <abroman@biostat.wisc.edu>
 Description: Gene set enrichment calculations for GO and KEGG
 Depends: R (>= 2.10), AnnotationDbi, graphics 
@@ -10,4 +10,4 @@ Suggests: hgu133plus2.db, GO.db, KEGG.db, reactome.db
 LazyLoad: yes
 LazyData: yes
 License: GPL (>= 2)
-Packaged: 2015-06-09; ningleng
+Packaged: 2015-06-16; ningleng

--- a/R/allez.R
+++ b/R/allez.R
@@ -107,6 +107,7 @@ allez <- function (scores,
 		SYMBOL=data.frame(cbind(gene_id=set2eg$gene_id[match(localunlist,set2eg$symbol)], 
 			go_id=unlist(sapply(1:locallen,function(k)rep(paste0("Local:",names(locallist)[k]),localeachlen[k]),simplify=F)),
 			Evidence="local", Ontology="local",symbol=localunlist),stringsAsFactors=F))
+		if(set_id=="path_id")names(newlist)[2] <- set_id
 		set2eg <- rbind(newlist,set2eg)
 		}
 		set2eg <- switch(idtype, ENTREZID=set2eg[set2eg$gene_id %in% names(scores),],

--- a/R/allez.R
+++ b/R/allez.R
@@ -35,7 +35,7 @@ allez <- function (scores,
   # cannot perform local test if input local lists
   if(universe=="local" & !is.null(locallist)){
     universe="global"
-    warning("input local list! changed to universe='global' ")
+    warning("universe='local' mode is not available when including local list! using universe='global' mode")
   }
   
   if (any(duplicated(scorenames))) 
@@ -107,7 +107,8 @@ allez <- function (scores,
 		SYMBOL=data.frame(cbind(gene_id=set2eg$gene_id[match(localunlist,set2eg$symbol)], 
 			go_id=unlist(sapply(1:locallen,function(k)rep(paste0("Local:",names(locallist)[k]),localeachlen[k]),simplify=F)),
 			Evidence="local", Ontology="local",symbol=localunlist),stringsAsFactors=F))
-		if(set_id=="path_id")names(newlist)[2] <- set_id
+		names(newlist)[2] <- set_id
+		if(set_id=="path_id")newlist <- newlist[c("gene_id","path_id", "symbol")]
 		set2eg <- rbind(newlist,set2eg)
 		}
 		set2eg <- switch(idtype, ENTREZID=set2eg[set2eg$gene_id %in% names(scores),],

--- a/R/allez.R
+++ b/R/allez.R
@@ -21,6 +21,8 @@ allez <- function (scores,
     warning("scores containing NA's will be excluded")
     scores <- scores[!is.na(scores)]
   }
+  
+
 
   scorenames <- names(scores)
   sets <- match.arg(sets)
@@ -28,8 +30,14 @@ allez <- function (scores,
   transform <- match.arg(transform)
   collapse <- match.arg(collapse)
   setstat <- match.arg(setstat)
-	idtype <- match.arg(idtype)
-
+  idtype <- match.arg(idtype)
+  
+  # cannot perform local test if input local lists
+  if(universe=="local" & !is.null(locallist)){
+    universe="global"
+    warning("input local list! changed to universe='global' ")
+  }
+  
   if (any(duplicated(scorenames))) 
     stop("input IDs must be unique")
   if( !is.numeric(scores) ) 
@@ -81,7 +89,7 @@ allez <- function (scores,
     ## Remove gene_ids not on microarray or scores##
      if(!is.org){
        probe2eg <- switch(idtype,ENTREZID=toTable(getDataEnv(name="ENTREZID",lib=lib[1])),
-         SYMBOLgetDataEnv(name="SYMBOL",lib=lib[1]))
+         SYMBOL=getDataEnv(name="SYMBOL",lib=lib[1]))
        probe2eg <- probe2eg[probe2eg$probe_id %in% names(scores),]
        egs <- switch(idtype, ENTREZID=unique(probe2eg[,"gene_id"]), SYMBOL=unique(probe2eg[,"symbol"]))
        set2eg <- switch(idtype, ENTREZID=set2eg[set2eg$gene_id %in% egs,], SYMBOL=set2eg[set2eg$symbol %in% egs,])

--- a/R/allez.R
+++ b/R/allez.R
@@ -1,8 +1,10 @@
 
 allez <- function (scores,
                    lib,
+                   idtype = c("ENTREZID", "SYMBOL"),
                    library.loc=NULL,
                    sets = c("GO","KEGG"),
+                   locallist = NULL,
                    collapse = c("full", "partial", "none"),
                    reduce = NULL,
                    setstat = c("mean", "var"),
@@ -26,6 +28,7 @@ allez <- function (scores,
   transform <- match.arg(transform)
   collapse <- match.arg(collapse)
   setstat <- match.arg(setstat)
+	idtype <- match.arg(idtype)
 
   if (any(duplicated(scorenames))) 
     stop("input IDs must be unique")
@@ -55,7 +58,7 @@ allez <- function (scores,
 
   set_id <- switch(sets, GO="go_id", KEGG="path_id")
   is.org <- substr(lib,1,3)=="org"
-  orgpkg <- ifelse(is.org,lib[1],get(paste(lib[1],"ORGPKG",sep="")))
+  orgpkg <- ifelse(is.org,lib[1],paste(lib[1],"ORGPKG",sep=""))
 
   ## ANNOTATION ##
   message("Converting annotations to data.frames ...")
@@ -77,20 +80,40 @@ allez <- function (scores,
               match(set2eg$gene_id,org.symbol$gene_id),"symbol",drop=FALSE])
     ## Remove gene_ids not on microarray or scores##
      if(!is.org){
-       probe2eg <- toTable(getDataEnv(name="ENTREZID",lib=lib[1]))
+       probe2eg <- switch(idtype,ENTREZID=toTable(getDataEnv(name="ENTREZID",lib=lib[1])),
+         SYMBOLgetDataEnv(name="SYMBOL",lib=lib[1]))
        probe2eg <- probe2eg[probe2eg$probe_id %in% names(scores),]
-       egs <- unique(probe2eg[,"gene_id"])
-       set2eg <- set2eg[set2eg$gene_id %in% egs,]
-     } else set2eg <- set2eg[set2eg$gene_id %in% names(scores),]
-  }
+       egs <- switch(idtype, ENTREZID=unique(probe2eg[,"gene_id"]), SYMBOL=unique(probe2eg[,"symbol"]))
+       set2eg <- switch(idtype, ENTREZID=set2eg[set2eg$gene_id %in% egs,], SYMBOL=set2eg[set2eg$symbol %in% egs,])
+     } else {
+# local list
+		if(!is.null(locallist)){
+		if(is.null(names(locallist)))names(locallist) = paste0("L",1:length(locallist))
+		localunlist=unlist(locallist)
+		locallen=length(locallist)
+		localeachlen=sapply(locallist,length)
+		newlist <- switch(idtype, ENTREZID=data.frame(cbind(gene_id=localunlist,
+			go_id=unlist(sapply(1:locallen,function(k)rep(paste0("Local:",names(locallist)[k]),localeachlen[k]),simplify=F)),
+			Evidence="local", Ontology="local",symbol=set2eg$symbol[match(localunlist,set2eg$gene_id)]
+		),stringsAsFactors=F),
+		SYMBOL=data.frame(cbind(gene_id=set2eg$gene_id[match(localunlist,set2eg$symbol)], 
+			go_id=unlist(sapply(1:locallen,function(k)rep(paste0("Local:",names(locallist)[k]),localeachlen[k]),simplify=F)),
+			Evidence="local", Ontology="local",symbol=localunlist),stringsAsFactors=F))
+		set2eg <- rbind(newlist,set2eg)
+		}
+		set2eg <- switch(idtype, ENTREZID=set2eg[set2eg$gene_id %in% names(scores),],
+			SYMBOL=set2eg[set2eg$symbol %in% names(scores),])
+		}}
 
   ## SCORES ##
   if(collapse == "full" & !is.org){
       message("Reducing probe data to gene data...")
       pscores <- data.frame(probe2eg,scores=scores[probe2eg$probe_id])
-      scores <- unlist(tapply(pscores$scores,as.character(pscores$gene_id),
-                       FUN=reduce,simplify=FALSE))
-    }
+      scores <- switch(idtype, ENTREZID=unlist(tapply(pscores$scores,as.character(pscores$gene_id),
+        FUN=reduce,simplify=FALSE)),
+        SYMBOL=unlist(tapply(pscores$scores,as.character(pscores$symbol),
+        FUN=reduce,simplify=FALSE)))
+}
   gscores <- switch(transform,
              none = scores,
              rank = rank(scores),
@@ -105,7 +128,8 @@ allez <- function (scores,
     data.frame(set2probe,gscores=gscores[set2probe$probe_id])
   } else {
     set2eg <- unique(set2eg[,c(set_id, 'gene_id', 'symbol')])
-    data.frame(set2eg,gscores=gscores[set2eg$gene_id])
+    switch(idtype, ENTREZID=data.frame(set2eg,gscores=gscores[set2eg$gene_id]),
+      SYMBOL=data.frame(set2eg,gscores=gscores[set2eg$symbol]))
   }
   set.mean <- unlist(tapply(set.data$gscores,set.data[[set_id]],
                       mean, simplify=FALSE))
@@ -115,13 +139,14 @@ allez <- function (scores,
   class(set.size) <- "array"
 
 ## Globe variable ##
+	cl <- switch(idtype, ENTREZID="gene_id",SYMBOL="symbol")
   globe <- if(sets=="GO"){
     ## GO:0008150 = bio process ##
     ## GO:0003674 = mol function ##
     ## GO:0005575 = cel component ##
     bpmfcc <- c("GO:0008150","GO:0003674","GO:0005575")
-    gscores[unique(set.data[set.data[,1] %in% bpmfcc,2])]
-  } else gscores[unique(set.data[,2])]
+    gscores[unique(set.data[set.data[,1] %in% bpmfcc,cl])]
+  } else gscores[unique(set.data[,cl])]
 
   mu.globe <- mean(globe)
   sigma.globe <- sd(globe)
@@ -142,7 +167,8 @@ allez <- function (scores,
     }
   
     if (!is.org & collapse == "partial") {
-      set.ng <-  table(unique(set2eg[,c(set_id,"gene_id")])[,1])
+      set.ng <-  switch(idtype, ENTREZID=table(unique(set2eg[,c(set_id,"gene_id")])[,1]),
+          SYMBOL=table(unique(set2eg[,c(set_id,"symbol")])[,1]))
       class(set.ng) <- "array"
       z.score <- z.score * sqrt(set.ng[names(z.score)]/
                                 set.size[names(z.score)])
@@ -157,7 +183,8 @@ allez <- function (scores,
   if(universe=="local"){
     set.names <- if(collapse=="none" & !is.org)
       tapply(set2probe$probe_id, set2probe$go_id,c) else
-      tapply(set2eg$gene_id,set2eg$go_id,c)
+      switch(idtype, ENTREZID=tapply(set2eg$gene_id,set2eg$go_id,c),
+        SYMBOL=tapply(set2eg$symbol,set2eg$go_id,c))
 
     go.id <- unique(set.data$go_id)
 

--- a/man/allez.Rd
+++ b/man/allez.Rd
@@ -15,8 +15,8 @@
  identify sets that show unusual variance characteristics.
 }
 \usage{
-allez(scores, lib, library.loc = NULL, sets = c("GO", "KEGG"), collapse
-= c("full","partial","none"), reduce = NULL, setstat = c("mean", "var"),
+allez(scores, lib, idtype = c("ENTREZID", "SYMBOL"),library.loc = NULL, sets = c("GO", "KEGG"), 
+locallist = NULL, collapse = c("full","partial","none"), reduce = NULL, setstat = c("mean", "var"),
 universe = c("global", "local"), transform = c("none", "binary", "rank",
 "nscore"), cutoff = NULL, annotate = TRUE, ...)
 }
@@ -40,11 +40,19 @@ universe = c("global", "local"), transform = c("none", "binary", "rank",
   (\code{"org.Hs.eg"}). A vector of package names is allowed in case
   multiple chips are used (e.g \code{"moe430a"} and \code{"moe430b"} 
   cover the mouse genome.) }
+\item{idtype}{idtype could be either \code{"ENTREZID"} (default) or 
+	\code{"SYMBOL"}. It should match
+names of the scores vector.}
 \item{library.loc}{
 %%     ~~Describe \code{library.loc} here~~
 }
 \item{sets}{character string, describing the collection of
   sets. \code{"GO"} (default) or \code{"KEGG"}}
+\item{locallist}{list contains in-house gene sets of interest. Default is NULL.
+Each element in the list represents a gene set. Each element should be a character
+string containing genes' entrez IDs (if \code{idtype="ENTREZID")} or
+gene symbols (if \code{idtype="STMBOL")}. Element names will be used as 
+set names. If \code{locallist} is not NULL, \code{universe="local"} will be disabled.}
 \item{collapse}{character string, describing the method for reducing
   probe-level data to gene-level data. \code{"full"} (default) uses the
   function \code{reduce} to reduce from 


### PR DESCRIPTION
boost the pkg version to 2.0.4
added 2 parameters 
idtype: allow users to use gene symbol instead of entrez id
locallist: in-house marker lists